### PR TITLE
Modernize stack and decouple EntryProcessor from graphql-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,30 +17,30 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.13.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.11.2</version>
                     <configuration>
-                        <source>8</source>
+                        <source>17</source>
                     </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.0.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
+                    <version>3.2.7</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -49,13 +49,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.2.6.RELEASE</version>
+                <version>3.5.12</version>
             </plugin>
         </plugins>
     </build>
@@ -64,17 +64,18 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>17.4</version>
+            <version>25.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.oracle.coherence.ce</groupId>
             <artifactId>coherence</artifactId>
-            <version>20.06</version>
+            <version>25.03.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.6.2</version>
+            <version>6.0.3</version>
             <scope>test</scope>
         </dependency>
 
@@ -97,7 +98,7 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>3.6.0</version>
                         <executions>
                             <execution>
                                 <id>add-dev-source</id>
@@ -127,20 +128,14 @@
             </build>
             <dependencies>
                 <dependency>
-                    <groupId>com.graphql-java-kickstart</groupId>
-                    <artifactId>graphql-spring-boot-starter</artifactId>
-                    <version>7.1.0</version>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-graphql</artifactId>
+                    <version>3.5.12</version>
                 </dependency>
                 <dependency>
-                    <groupId>com.graphql-java-kickstart</groupId>
-                    <artifactId>graphiql-spring-boot-starter</artifactId>
-                    <version>7.1.0</version>
-                    <scope>runtime</scope>
-                </dependency>
-                <dependency>
-                    <groupId>com.graphql-java-kickstart</groupId>
-                    <artifactId>graphql-java-tools</artifactId>
-                    <version>6.1.0</version>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-web</artifactId>
+                    <version>3.5.12</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/src/dev/java/net/unit8/cohegraph/example/CoheGraphQueryResolver.java
+++ b/src/dev/java/net/unit8/cohegraph/example/CoheGraphQueryResolver.java
@@ -2,25 +2,35 @@ package net.unit8.cohegraph.example;
 
 import com.tangosol.net.CacheFactory;
 import com.tangosol.net.NamedCache;
-import graphql.kickstart.tools.GraphQLQueryResolver;
 import graphql.schema.DataFetchingEnvironment;
+import net.unit8.cohegraph.FieldSelection;
+import net.unit8.cohegraph.FieldSelectionConverter;
 import net.unit8.cohegraph.GraphQLEntryProcessor;
 import net.unit8.cohegraph.example.model.Author;
 import net.unit8.cohegraph.example.model.Book;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
 
 import java.util.Collection;
 
-public class CoheGraphQueryResolver implements GraphQLQueryResolver {
+@Controller
+public class CoheGraphQueryResolver {
+    @QueryMapping
     public Collection<Book> books(DataFetchingEnvironment environment) {
+        FieldSelection selection = FieldSelectionConverter.fromGraphQLField(
+                environment.getMergedField().getSingleField());
         GraphQLEntryProcessor<Long, Book> bookEntryProcessor
-                = new GraphQLEntryProcessor<>(Book.class, environment.getMergedField().getSingleField());
+                = new GraphQLEntryProcessor<>(Book.class, selection);
         NamedCache<Long, Book> books = CacheFactory.getCache("books");
         return books.invokeAll(bookEntryProcessor).values();
     }
 
+    @QueryMapping
     public Collection<Author> authors(DataFetchingEnvironment environment) {
+        FieldSelection selection = FieldSelectionConverter.fromGraphQLField(
+                environment.getMergedField().getSingleField());
         GraphQLEntryProcessor<Long, Author> authorEntryProcessor
-                = new GraphQLEntryProcessor<>(Author.class, environment.getMergedField().getSingleField());
+                = new GraphQLEntryProcessor<>(Author.class, selection);
         NamedCache<Long, Author> authors = CacheFactory.getCache("authors");
         return authors.invokeAll(authorEntryProcessor).values();
     }

--- a/src/dev/java/net/unit8/cohegraph/example/GraphQLApplication.java
+++ b/src/dev/java/net/unit8/cohegraph/example/GraphQLApplication.java
@@ -1,26 +1,10 @@
 package net.unit8.cohegraph.example;
 
-import graphql.kickstart.tools.GraphQLQueryResolver;
-import graphql.kickstart.tools.SchemaParser;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class GraphQLApplication {
-    @Bean
-    public SchemaParser schema(GraphQLQueryResolver resolver) {
-        return SchemaParser.newParser()
-                .file("graphql/schema.graphqls")
-                .resolvers(resolver)
-                .build();
-    }
-
-    @Bean
-    public GraphQLQueryResolver queryResolver() {
-        return new CoheGraphQueryResolver();
-    }
-
     public static void main(String[] args) {
         SpringApplication.run(GraphQLApplication.class, args);
     }

--- a/src/dev/resources/application.yml
+++ b/src/dev/resources/application.yml
@@ -1,21 +1,13 @@
 spring:
   application:
     name: cohegraph
+  graphql:
+    graphiql:
+      enabled: true
+    schema:
+      introspection:
+        enabled: true
+    cors:
+      allowed-origins: "*"
 server:
   port: 9000
-graphql:
-  servlet:
-    actuator-metrics: true
-    mapping: /graphql
-    enabled: true
-    corsEnabled: true
-    exception-handlers-enabled: true
-    contextSetting: PER_REQUEST_WITH_INSTRUMENTATION
-  tools:
-    schema-location-pattern: "**/*.graphqls"
-    introspection-enabled: true
-graphiql:
-  enabled: true
-  mapping: /graphiql
-  endpoint:
-    graphql: /graphql

--- a/src/dev/resources/tangosol-coherence-override.xml
+++ b/src/dev/resources/tangosol-coherence-override.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<coherence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns="http://xmlns.oracle.com/coherence/coherence-operational-config"
+           xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-operational-config coherence-operational-config.xsd">
+
+  <cluster-config>
+    <unicast-listener>
+      <well-known-addresses>
+        <socket-address id="1">
+          <address>127.0.0.1</address>
+          <port>7574</port>
+        </socket-address>
+      </well-known-addresses>
+    </unicast-listener>
+  </cluster-config>
+</coherence>

--- a/src/main/java/net/unit8/cohegraph/FieldSelection.java
+++ b/src/main/java/net/unit8/cohegraph/FieldSelection.java
@@ -1,0 +1,32 @@
+package net.unit8.cohegraph;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class FieldSelection implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String name;
+    private final List<FieldSelection> children;
+
+    public FieldSelection(String name, List<FieldSelection> children) {
+        this.name = name;
+        this.children = children != null ? children : Collections.emptyList();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<FieldSelection> getChildren() {
+        return children;
+    }
+
+    public Optional<FieldSelection> getChild(String name) {
+        return children.stream()
+                .filter(c -> c.getName().equals(name))
+                .findFirst();
+    }
+}

--- a/src/main/java/net/unit8/cohegraph/FieldSelectionConverter.java
+++ b/src/main/java/net/unit8/cohegraph/FieldSelectionConverter.java
@@ -1,0 +1,23 @@
+package net.unit8.cohegraph;
+
+import graphql.language.Field;
+import graphql.language.SelectionSet;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class FieldSelectionConverter {
+    public static FieldSelection fromGraphQLField(Field field) {
+        List<FieldSelection> children = Collections.emptyList();
+        SelectionSet selectionSet = field.getSelectionSet();
+        if (selectionSet != null) {
+            children = selectionSet.getSelections().stream()
+                    .filter(Field.class::isInstance)
+                    .map(Field.class::cast)
+                    .map(FieldSelectionConverter::fromGraphQLField)
+                    .collect(Collectors.toList());
+        }
+        return new FieldSelection(field.getName(), children);
+    }
+}

--- a/src/main/java/net/unit8/cohegraph/GraphQLEntryProcessor.java
+++ b/src/main/java/net/unit8/cohegraph/GraphQLEntryProcessor.java
@@ -22,10 +22,10 @@ import java.util.stream.Collectors;
 
 public class GraphQLEntryProcessor<K, V> extends AbstractProcessor<K, V, V> {
     private final Map<String, JoinProcessor> joinProcessors = new HashMap<>();
-    private final graphql.language.Field field;
+    private final FieldSelection fieldSelection;
 
-    public GraphQLEntryProcessor(Class<V> modelClass, graphql.language.Field field) {
-        this.field = field;
+    public GraphQLEntryProcessor(Class<V> modelClass, FieldSelection fieldSelection) {
+        this.fieldSelection = fieldSelection;
         Arrays.stream(modelClass.getDeclaredFields())
                 .filter(f -> f.getAnnotation(JoinCache.class) != null)
                 .map(f -> joinCache(modelClass, f))
@@ -54,24 +54,21 @@ public class GraphQLEntryProcessor<K, V> extends AbstractProcessor<K, V, V> {
             throw new IllegalStateException(e);
         }
     }
+
     @Override
     public V process(InvocableMap.Entry<K, V> entry) {
         V value = entry.getValue();
         BackingMapManagerContext managerContext = ((BinaryEntry<K, V>) entry).getContext();
         Converter<Object, Binary> keyToInternalConverter = managerContext.getKeyToInternalConverter();
-        List<graphql.language.Field> childFields = field.getSelectionSet().getSelections()
-                .stream()
-                .filter(graphql.language.Field.class::isInstance)
-                .map(graphql.language.Field.class::cast)
-                .collect(Collectors.toList());
+        List<FieldSelection> childSelections = fieldSelection.getChildren();
 
         joinProcessors.entrySet()
                 .stream()
-                .filter(e -> childFields.stream()
-                        .anyMatch(f -> f.getName().equals(e.getKey())))
+                .filter(e -> childSelections.stream()
+                        .anyMatch(s -> s.getName().equals(e.getKey())))
                 .forEach(e -> {
-                    graphql.language.Field field = childFields.stream()
-                            .filter(f -> f.getName().equals(e.getKey()))
+                    FieldSelection childSelection = childSelections.stream()
+                            .filter(s -> s.getName().equals(e.getKey()))
                             .findFirst()
                             .orElseThrow();
                     BackingMapContext context = managerContext.getBackingMapContext(e.getValue().getCacheName());
@@ -81,14 +78,14 @@ public class GraphQLEntryProcessor<K, V> extends AbstractProcessor<K, V, V> {
                                 .map(i -> {
                                     Binary key = keyToInternalConverter.convert(i);
                                     InvocableMap.Entry childEntry = context.getReadOnlyEntry(key);
-                                    return new GraphQLEntryProcessor<>(childEntry.getValue().getClass(), field)
+                                    return new GraphQLEntryProcessor<>(childEntry.getValue().getClass(), childSelection)
                                             .process(childEntry);
                                 }).collect(Collectors.toList());
                         e.getValue().setProperty(value, properties);
                     } else {
                         Binary key = keyToInternalConverter.convert(id);
                         InvocableMap.Entry propertyEntry = context.getReadOnlyEntry(key);
-                        Object prop = new GraphQLEntryProcessor<>(propertyEntry.getValue().getClass(), field)
+                        Object prop = new GraphQLEntryProcessor<>(propertyEntry.getValue().getClass(), childSelection)
                                 .process(propertyEntry);
                         e.getValue().setProperty(value, prop);
                     }

--- a/src/test/java/net/unit8/cohegraph/FieldSelectionConverterTest.java
+++ b/src/test/java/net/unit8/cohegraph/FieldSelectionConverterTest.java
@@ -1,0 +1,74 @@
+package net.unit8.cohegraph;
+
+import graphql.language.Field;
+import graphql.language.SelectionSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FieldSelectionConverterTest {
+
+    @Test
+    void fromGraphQLField_leafField() {
+        Field field = Field.newField("name").build();
+
+        FieldSelection result = FieldSelectionConverter.fromGraphQLField(field);
+
+        assertThat(result.getName()).isEqualTo("name");
+        assertThat(result.getChildren()).isEmpty();
+    }
+
+    @Test
+    void fromGraphQLField_withChildren() {
+        Field nameField = Field.newField("name").build();
+        Field pageCountField = Field.newField("pageCount").build();
+        Field booksField = Field.newField("books")
+                .selectionSet(new SelectionSet(List.of(nameField, pageCountField)))
+                .build();
+
+        FieldSelection result = FieldSelectionConverter.fromGraphQLField(booksField);
+
+        assertThat(result.getName()).isEqualTo("books");
+        assertThat(result.getChildren()).hasSize(2);
+        assertThat(result.getChildren().get(0).getName()).isEqualTo("name");
+        assertThat(result.getChildren().get(1).getName()).isEqualTo("pageCount");
+    }
+
+    @Test
+    void fromGraphQLField_nestedSelections() {
+        Field firstNameField = Field.newField("firstName").build();
+        Field lastNameField = Field.newField("lastName").build();
+        Field authorField = Field.newField("author")
+                .selectionSet(new SelectionSet(List.of(firstNameField, lastNameField)))
+                .build();
+        Field nameField = Field.newField("name").build();
+        Field booksField = Field.newField("books")
+                .selectionSet(new SelectionSet(List.of(nameField, authorField)))
+                .build();
+
+        FieldSelection result = FieldSelectionConverter.fromGraphQLField(booksField);
+
+        assertThat(result.getName()).isEqualTo("books");
+        assertThat(result.getChildren()).hasSize(2);
+
+        FieldSelection authorSelection = result.getChild("author").orElseThrow();
+        assertThat(authorSelection.getChildren()).hasSize(2);
+        assertThat(authorSelection.getChildren().get(0).getName()).isEqualTo("firstName");
+        assertThat(authorSelection.getChildren().get(1).getName()).isEqualTo("lastName");
+    }
+
+    @Test
+    void fromGraphQLField_emptySelectionSet() {
+        Field field = Field.newField("books")
+                .selectionSet(new SelectionSet(Collections.emptyList()))
+                .build();
+
+        FieldSelection result = FieldSelectionConverter.fromGraphQLField(field);
+
+        assertThat(result.getName()).isEqualTo("books");
+        assertThat(result.getChildren()).isEmpty();
+    }
+}

--- a/src/test/java/net/unit8/cohegraph/FieldSelectionTest.java
+++ b/src/test/java/net/unit8/cohegraph/FieldSelectionTest.java
@@ -1,0 +1,59 @@
+package net.unit8.cohegraph;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FieldSelectionTest {
+
+    @Test
+    void getName_returnsName() {
+        FieldSelection sel = new FieldSelection("books", Collections.emptyList());
+        assertThat(sel.getName()).isEqualTo("books");
+    }
+
+    @Test
+    void getChildren_returnsChildren() {
+        FieldSelection child1 = new FieldSelection("name", Collections.emptyList());
+        FieldSelection child2 = new FieldSelection("author", Collections.emptyList());
+        FieldSelection sel = new FieldSelection("books", List.of(child1, child2));
+
+        assertThat(sel.getChildren()).hasSize(2);
+        assertThat(sel.getChildren().get(0).getName()).isEqualTo("name");
+        assertThat(sel.getChildren().get(1).getName()).isEqualTo("author");
+    }
+
+    @Test
+    void getChildren_nullDefaultsToEmptyList() {
+        FieldSelection sel = new FieldSelection("books", null);
+        assertThat(sel.getChildren()).isEmpty();
+    }
+
+    @Test
+    void getChild_findsExistingChild() {
+        FieldSelection child = new FieldSelection("author", Collections.emptyList());
+        FieldSelection sel = new FieldSelection("books", List.of(child));
+
+        assertThat(sel.getChild("author")).isPresent();
+        assertThat(sel.getChild("author").get().getName()).isEqualTo("author");
+    }
+
+    @Test
+    void getChild_returnsEmptyForMissing() {
+        FieldSelection sel = new FieldSelection("books", Collections.emptyList());
+        assertThat(sel.getChild("nonexistent")).isEmpty();
+    }
+
+    @Test
+    void nestedTree_preservesStructure() {
+        FieldSelection grandchild = new FieldSelection("firstName", Collections.emptyList());
+        FieldSelection child = new FieldSelection("author", List.of(grandchild));
+        FieldSelection root = new FieldSelection("books", List.of(child));
+
+        assertThat(root.getChild("author")).isPresent();
+        assertThat(root.getChild("author").get().getChild("firstName")).isPresent();
+    }
+}

--- a/src/test/java/net/unit8/cohegraph/GraphQLEntryProcessorTest.java
+++ b/src/test/java/net/unit8/cohegraph/GraphQLEntryProcessorTest.java
@@ -1,0 +1,119 @@
+package net.unit8.cohegraph;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GraphQLEntryProcessorTest {
+
+    public static class SimpleModel implements Serializable {
+        private final Long id;
+        private final String name;
+
+        public SimpleModel(Long id, String name) {
+            this.id = id;
+            this.name = name;
+        }
+
+        public Long getId() { return id; }
+        public String getName() { return name; }
+    }
+
+    public static class ModelWithJoin implements Serializable {
+        private final Long id;
+        private final Long parentId;
+
+        @JoinCache(name = "parents", idProperty = "parentId")
+        private volatile SimpleModel parent;
+
+        public ModelWithJoin(Long id, Long parentId) {
+            this.id = id;
+            this.parentId = parentId;
+        }
+
+        public Long getId() { return id; }
+        public Long getParentId() { return parentId; }
+        public SimpleModel getParent() { return parent; }
+        public void setParent(SimpleModel parent) { this.parent = parent; }
+    }
+
+    public static class ModelWithMultipleJoins implements Serializable {
+        private final Long id;
+        private final Long authorId;
+        private final List<Long> tagIds;
+
+        @JoinCache(name = "authors", idProperty = "authorId")
+        private volatile SimpleModel author;
+
+        @JoinCache(name = "tags", idProperty = "tagIds")
+        private volatile List<SimpleModel> tags;
+
+        public ModelWithMultipleJoins(Long id, Long authorId, List<Long> tagIds) {
+            this.id = id;
+            this.authorId = authorId;
+            this.tagIds = tagIds;
+        }
+
+        public Long getId() { return id; }
+        public Long getAuthorId() { return authorId; }
+        public List<Long> getTagIds() { return tagIds; }
+        public SimpleModel getAuthor() { return author; }
+        public void setAuthor(SimpleModel author) { this.author = author; }
+        public List<SimpleModel> getTags() { return tags; }
+        public void setTags(List<SimpleModel> tags) { this.tags = tags; }
+    }
+
+    private FieldSelection selection(String name, FieldSelection... children) {
+        return new FieldSelection(name, Arrays.asList(children));
+    }
+
+    @Test
+    void constructor_noJoinAnnotations_createsEmptyProcessors() {
+        FieldSelection sel = selection("simple");
+
+        GraphQLEntryProcessor<Long, SimpleModel> processor =
+                new GraphQLEntryProcessor<>(SimpleModel.class, sel);
+
+        assertThat(processor).isNotNull();
+    }
+
+    @Test
+    void constructor_withSingleJoinAnnotation_createsOneProcessor() {
+        FieldSelection sel = selection("model");
+
+        GraphQLEntryProcessor<Long, ModelWithJoin> processor =
+                new GraphQLEntryProcessor<>(ModelWithJoin.class, sel);
+
+        assertThat(processor).isNotNull();
+    }
+
+    @Test
+    void constructor_withMultipleJoinAnnotations_createsMultipleProcessors() {
+        FieldSelection sel = selection("model");
+
+        GraphQLEntryProcessor<Long, ModelWithMultipleJoins> processor =
+                new GraphQLEntryProcessor<>(ModelWithMultipleJoins.class, sel);
+
+        assertThat(processor).isNotNull();
+    }
+
+    @Test
+    void constructor_withNestedSelections() {
+        FieldSelection sel = selection("books",
+                selection("name"),
+                selection("author",
+                        selection("firstName"),
+                        selection("lastName")),
+                selection("tags",
+                        selection("name")));
+
+        GraphQLEntryProcessor<Long, ModelWithMultipleJoins> processor =
+                new GraphQLEntryProcessor<>(ModelWithMultipleJoins.class, sel);
+
+        assertThat(processor).isNotNull();
+    }
+}

--- a/src/test/java/net/unit8/cohegraph/JoinProcessorTest.java
+++ b/src/test/java/net/unit8/cohegraph/JoinProcessorTest.java
@@ -1,0 +1,102 @@
+package net.unit8.cohegraph;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JoinProcessorTest {
+
+    public static class SampleModel implements Serializable {
+        private final Long id;
+        private final Long parentId;
+        private final List<Long> childIds;
+        private Object parent;
+        private List<Object> children;
+
+        public SampleModel(Long id, Long parentId, List<Long> childIds) {
+            this.id = id;
+            this.parentId = parentId;
+            this.childIds = childIds;
+        }
+
+        public Long getId() { return id; }
+        public Long getParentId() { return parentId; }
+        public List<Long> getChildIds() { return childIds; }
+        public Object getParent() { return parent; }
+        public void setParent(Object parent) { this.parent = parent; }
+        public List<Object> getChildren() { return children; }
+        public void setChildren(List<Object> children) { this.children = children; }
+    }
+
+    @Test
+    void getId_returnsSingleId() {
+        JoinProcessor processor = new JoinProcessor("parent", "parents", "getParentId", "setParent");
+        SampleModel model = new SampleModel(1L, 42L, List.of(10L, 20L));
+
+        Object id = processor.getId(model);
+
+        assertThat(id).isEqualTo(42L);
+    }
+
+    @Test
+    void getId_returnsListOfIds() {
+        JoinProcessor processor = new JoinProcessor("children", "childCache", "getChildIds", "setChildren");
+        SampleModel model = new SampleModel(1L, 42L, List.of(10L, 20L));
+
+        Object id = processor.getId(model);
+
+        assertThat(id).isInstanceOf(List.class);
+        @SuppressWarnings("unchecked")
+        List<Long> idList = (List<Long>) id;
+        assertThat(idList).containsExactly(10L, 20L);
+    }
+
+    @Test
+    void setProperty_setsSingleValue() {
+        JoinProcessor processor = new JoinProcessor("parent", "parents", "getParentId", "setParent");
+        SampleModel model = new SampleModel(1L, 42L, List.of());
+        String parentValue = "parentObject";
+
+        processor.setProperty(model, parentValue);
+
+        assertThat(model.getParent()).isEqualTo("parentObject");
+    }
+
+    @Test
+    void setProperty_setsList() {
+        JoinProcessor processor = new JoinProcessor("children", "childCache", "getChildIds", "setChildren");
+        SampleModel model = new SampleModel(1L, 42L, List.of());
+        List<Object> children = List.of("child1", "child2");
+
+        processor.setProperty(model, children);
+
+        assertThat(model.getChildren()).containsExactly("child1", "child2");
+    }
+
+    @Test
+    void getName_returnsFieldName() {
+        JoinProcessor processor = new JoinProcessor("parent", "parents", "getParentId", "setParent");
+
+        assertThat(processor.getName()).isEqualTo("parent");
+    }
+
+    @Test
+    void getCacheName_returnsCacheName() {
+        JoinProcessor processor = new JoinProcessor("parent", "parents", "getParentId", "setParent");
+
+        assertThat(processor.getCacheName()).isEqualTo("parents");
+    }
+
+    @Test
+    void getId_throwsForInvalidGetter() {
+        JoinProcessor processor = new JoinProcessor("parent", "parents", "nonExistentMethod", "setParent");
+        SampleModel model = new SampleModel(1L, 42L, List.of());
+
+        assertThatThrownBy(() -> processor.getId(model))
+                .isInstanceOf(RuntimeException.class);
+    }
+}


### PR DESCRIPTION
## Summary
- Upgrade to Java 17, Spring Boot 3.5.12, Coherence CE 25.03.2, graphql-java 25.0, JUnit 6.0.3
- Replace deprecated graphql-java-kickstart with Spring for GraphQL (`@Controller` + `@QueryMapping`)
- Introduce `FieldSelection` (pure Serializable tree) to replace `graphql.language.Field` in `GraphQLEntryProcessor`, eliminating graphql-java dependency from Coherence server classpath
- Add unit tests (21 tests) and WKA config for local development

## Test plan
- [x] `mvn compile -P '!dev'` — core library compiles without graphql-java at runtime
- [x] `mvn test` — 21 unit tests pass
- [x] Coherence server + data setup + Spring Boot app — books query with nested author/publisher JOIN
- [x] Authors query with one-to-many books JOIN

🤖 Generated with [Claude Code](https://claude.com/claude-code)